### PR TITLE
処理する電話番号の条件を、+81から始まる番号のみに変更しました

### DIFF
--- a/slackbot-phonenumber.rb
+++ b/slackbot-phonenumber.rb
@@ -44,7 +44,7 @@ client.on :message do |data|
   case data.attachments ? data.text+data.attachments.to_s : data.text
   when 'bot hi' then
     client.message(channel: data.channel, text: "Hi <@#{data.user}>!")
-  when /(\+[\-\d]{3,}\d)/ then
+  when /(\+81[\-\d]{1,}\d)/ then
     n = $1.gsub(/^\+81/, '0')
     result = phonenumber_search(n)
     result = "なし" unless result


### PR DESCRIPTION
後続の処理が+81から始まる番号を前提としているため、また、電話帳ナビは海外の番号に対応してませんので、+81から始まる番号(日本の電話番号)のみ処理するようにしました。